### PR TITLE
Add missing include

### DIFF
--- a/main.c
+++ b/main.c
@@ -12,6 +12,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
Hello,
There are some errors when compiling with my Get_Next_Line because stdlib.h is missing in main.c.
The script complains that the malloc and free functions are not defined.
Here is a small fix for the problem!